### PR TITLE
Fix titles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,6 @@ matrix:
     sudo: required
     dist: trusty
     services: docker
-    env: BEAKER_set="debian-7"
-    bundler_args:
-    script: sudo service docker restart ; sleep 10 && bundle exec rspec spec/acceptance/*_spec.rb
-  - rvm: default
-    sudo: required
-    dist: trusty
-    services: docker
     env: BEAKER_set="debian-8"
     bundler_args:
     script: sudo service docker restart ; sleep 10 && bundle exec rspec spec/acceptance/*_spec.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ script: ["bundle exec rake validate", "bundle exec rake lint", "bundle exec rake
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.1.10
+  - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4.0"
-  - rvm: 2.3.4
-    env: PUPPET_GEM_VERSION="~> 4"
+  - rvm: 2.4.1
+    env: PUPPET_GEM_VERSION="~> 5.0"
   - rvm: default
     sudo: required
     dist: trusty
@@ -78,4 +78,4 @@ deploy:
     # all_branches is required to use tags
     all_branches: true
     # Only publish if our main Ruby target builds
-    rvm: 2.1.10
+    rvm: 2.1.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,6 @@ matrix:
     sudo: required
     dist: trusty
     services: docker
-    env: BEAKER_set="debian-6"
-    bundler_args:
-    script: sudo service docker restart ; sleep 10 && bundle exec rspec spec/acceptance/*_spec.rb
-  - rvm: default
-    sudo: required
-    dist: trusty
-    services: docker
     env: BEAKER_set="debian-7"
     bundler_args:
     script: sudo service docker restart ; sleep 10 && bundle exec rspec spec/acceptance/*_spec.rb
@@ -36,6 +29,13 @@ matrix:
     dist: trusty
     services: docker
     env: BEAKER_set="debian-8"
+    bundler_args:
+    script: sudo service docker restart ; sleep 10 && bundle exec rspec spec/acceptance/*_spec.rb
+  - rvm: default
+    sudo: required
+    dist: trusty
+    services: docker
+    env: BEAKER_set="debian-9"
     bundler_args:
     script: sudo service docker restart ; sleep 10 && bundle exec rspec spec/acceptance/*_spec.rb
   - rvm: default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,249 +1,250 @@
 ## 2017-06-06 - Release 1.16.1
 
-Fix metadata.json
+- Fix metadata.json
 
 ## 2017-06-06 - Release 1.16.0
 
-Fixed bug for spaces in the "by" section of the rule
-Allow to set rewrite overlay with a relay database
-Fixes errata - puppet creates a rwm overlay every runs
-Any prefixed numbers should be absent in the options
-Refactor openldap::server::access
-Add security attribute to database resource
-Syncrepl now run idempotently
-Use ldapmodify function instead of the slapdd which is not defined
-Support Amazon linux 2015+ and make version checks more flexible
-Mod global conf
-Fix variables out of scope
-Make NETWORK_TIMEOUT a configurable option
-Use contain instead of include
-Fix ordering so that Openldap::Server::Globalconf resources will come after the openldap service
-Change updateref order to avoid error '<olcUpdateRef> must appear after syncrepl or updatedn
-Adding dbmaxsize parameter for big dbs
-Remove requirements from metadata.json
-Supports SHA2 password
-Allow openldap::client config values to have 'absent' value remove the entry from ldap.conf
-openldap_database: Default to mdb for new Ubuntus
+- Fixed bug for spaces in the "by" section of the rule
+- Allow to set rewrite overlay with a relay database
+- Fixes errata - puppet creates a rwm overlay every runs
+- Any prefixed numbers should be absent in the options
+- Refactor openldap::server::access
+- Add security attribute to database resource
+- Syncrepl now run idempotently
+- Use ldapmodify function instead of the slapdd which is not defined
+- Support Amazon linux 2015+ and make version checks more flexible
+- Mod global conf
+- Fix variables out of scope
+- Make NETWORK_TIMEOUT a configurable option
+- Use contain instead of include
+- Fix ordering so that Openldap::Server::Globalconf resources will come after the openldap service
+- Change updateref order to avoid error '<olcUpdateRef> must appear after syncrepl or updatedn
+- Adding dbmaxsize parameter for big dbs
+- Remove requirements from metadata.json
+- Supports SHA2 password
+- Allow openldap::client config values to have 'absent' value remove the entry from ldap.conf
+- openldap_database: Default to mdb for new Ubuntus
 
 ## 2016-08-22 - Release 1.15.0
 
-Add base provider that implements common commands and methods and use it
-Fixed an idempotency issue on the syncrepl variable
-Fix idempotency issue when ensuring absent of multiple databases
+- Add base provider that implements common commands and methods and use it
+- Fixed an idempotency issue on the syncrepl variable
+- Fix idempotency issue when ensuring absent of multiple databases
 
 ## 2016-02-18 - Release 1.14.0
 
-Add support for the rwm overlay (issue #117)
-Manage line breaks in overlay config and add smbk5pwd overlay support (issue #122)
-Avoid duplicate declaration of openldap-clients package (issue #123)
-Allow dn, filter and attrs to be defined concurrently (issue #124)
+- Add support for the rwm overlay (issue #117)
+- Manage line breaks in overlay config and add smbk5pwd overlay support (issue #122)
+- Avoid duplicate declaration of openldap-clients package (issue #123)
+- Allow dn, filter and attrs to be defined concurrently (issue #124)
 
 ## 2016-01-11 - Release 1.13.0
 
-Fix for frontend and config databases
-Add serveral params for ldap.conf to openldap::client.
-Add timeout and timelimit options
-Add sudo options
-Add binddn and bindpw options to ldap client
+- Fix for frontend and config databases
+- Add serveral params for ldap.conf to openldap::client.
+- Add timeout and timelimit options
+- Add sudo options
+- Add binddn and bindpw options to ldap client
 
 ## 2015-11-18 - Release 1.12.0
 
-Add objectClass for the unique overlay
-Support for adding access based on olcDatabase
-Fix prefetch with composite namevars
-Use puppet4 for acceptance tests
+- Add objectClass for the unique overlay
+- Support for adding access based on olcDatabase
+- Fix prefetch with composite namevars
+- Use puppet4 for acceptance tests
 
 ## 2015-11-09 - Release 1.11.0
 
-Do not try to hash password if it is given in "{SSHA}" form
-Add cn=config suffix support
-Add readonly support to openldap_database's augeas provider
+- Do not try to hash password if it is given in "{SSHA}" form
+- Add cn=config suffix support
+- Add readonly support to openldap_database's augeas provider
 
 ## 2015-10-09 - Release 1.10.0
 
-Fix ACL changes
-Fix syncprov overlay
-Add support for refint overlay
+- Fix ACL changes
+- Fix syncprov overlay
+- Add support for refint overlay
 
 ## 2015-08-21 - Release 1.9.2
 
-Use docker for acceptance tests
+- Use docker for acceptance tests
 
 ## 2015-07-08 - Release 1.9.1
 
-Fix TLS setting on new versions of OpenLDAP
+- Fix TLS setting on new versions of OpenLDAP
 
 ## 2015-07-08 - Release 1.9.0
 
-Add more parameters to openldap::server::database
-Add support for accesslog overlay
+- Add more parameters to openldap::server::database
+- Add support for accesslog overlay
 
 ## 2015-06-26 - Release 1.8.2
 
-Fix strict_variables activation with rspec-puppet 2.2
+- Fix strict_variables activation with rspec-puppet 2.2
 
 ## 2015-06-24 - Release 1.8.1
 
-Add missing 'ensure' parameter to 'openldap::server::globalconf'
+- Add missing 'ensure' parameter to 'openldap::server::globalconf'
 
 ## 2015-06-19 - Release 1.8.0
 
-Revert "Use ruby to generate idempotent SSHA password (more secure password)
-Add support to configure overlays on a database
-Fix some issues on Ubuntu (no official support yet)
-Update documentation
-Don't convert schema if already in LDIF format
+- Revert "Use ruby to generate idempotent SSHA password (more secure password)
+- Add support to configure overlays on a database
+- Fix some issues on Ubuntu (no official support yet)
+- Update documentation
+- Don't convert schema if already in LDIF format
 
 ## 2015-06-19 - Release 1.7.0
 
-Add `initdb` param to `openldap::server::database` define to allow to not
+- Add `initdb` param to `openldap::server::database` define to allow to not
 initialize database.
 
 ## 2015-05-28 - Release 1.6.5
 
-Add beaker_spec_helper to Gemfile
+- Add beaker_spec_helper to Gemfile
 
 ## 2015-05-26 - Release 1.6.4
 
-Use random application order in nodeset
+- Use random application order in nodeset
 
 ## 2015-05-26 - Release 1.6.3
 
-add utopic & vivid nodesets
+- add utopic & vivid nodesets
 
 ## 2015-05-25 - Release 1.6.2
 
-Don't allow failure on Puppet 4
+- Don't allow failure on Puppet 4
 
 ## 2015-05-13 - Release 1.6.1
 
-Add puppet-lint-file_source_rights-check gem
+- Add puppet-lint-file_source_rights-check gem
 
 ## 2015-05-13 - Release 1.6.0
 
-Add support for schema
+- Add support for schema
 
 ## 2015-05-12 - Release 1.5.5
 
-Don't pin beaker
+- Don't pin beaker
 
 ## 2015-05-12 - Release 1.5.4
 
-Add documentation for puppet::server::globalconf
-Fix Beaker on Docker
+- Add documentation for puppet::server::globalconf
+- Fix Beaker on Docker
 
 ## 2015-04-29 - Release 1.5.3
 
-Avoid logging password
+- Avoid logging password
 
 ## 2015-04-21 - Release 1.5.2
 
-Correct client package name for RHEL
+- Correct client package name for RHEL
 
 ## 2015-04-17 - Release 1.5.1
 
-Add beaker nodesets
+- Add beaker nodesets
 
 ## 2015-04-08 - Release 1.5.0
 
-Generate random salt for rootpw instead of using fqdn
-Deprecates openldap_password function
-Fix database destroy
+- Generate random salt for rootpw instead of using fqdn
+- Deprecates openldap_password function
+- Fix database destroy
 
 ## 2015-04-03 - Release 1.4.1
 
-Fix acceptance tests
+- Fix acceptance tests
 
 ## 2015-03-29 - Release 1.4.0
 
-Add more acceptance tests to travis matrix
-Confine pinning to rspec 3.1 to ruby 1.8
-openldap_password does not use slappasswd anymore
-openldap_password is idempotent
-Add MDB backend support
-Remove RedHat 5 support (may still work but not tested on travis)
-Add RedHat 7 support
-Add Debian 8 support
-Database creation don't require nis schema anymore
-Fix openldap_module on RedHat
-Set selinux to permissive on acceptance tests
+- Add more acceptance tests to travis matrix
+- Confine pinning to rspec 3.1 to ruby 1.8
+- openldap_password does not use slappasswd anymore
+- openldap_password is idempotent
+- Add MDB backend support
+- Remove RedHat 5 support (may still work but not tested on travis)
+- Add RedHat 7 support
+- Add Debian 8 support
+- Database creation don't require nis schema anymore
+- Fix openldap_module on RedHat
+- Set selinux to permissive on acceptance tests
 
 ## 2015-03-24 - Release 1.3.2
 
-Various spec improvements
-Fix specs
+- Various spec improvements
+- Fix specs
 
 ## 2015-03-06 - Release 1.3.1
 
-Destroy default database before creating new ones
+- Destroy default database before creating new ones
 
 ## 2015-02-18 - Release 1.3.0
 
-Use params pattern
-Some minor fixes
+- Use params pattern
+- Some minor fixes
 
 ## 2015-01-07 - Release 1.2.3
 
-Fix unquoted strings in cases
+- Fix unquoted strings in cases
 
 ## 2015-01-05 - Release 1.2.2
 
-Fix .travis.yml
+- Fix .travis.yml
 
 ## 2014-12-18 - Release 1.2.1
 
-Various improvements in unit tests
+- Various improvements in unit tests
 
 ## 2014-12-09 Release 1.2.0
-Fix metadata.json
-Add future parser tests
-Fix code for future parser
-Migrate tests to rspec 3 syntax
-Use puppet_facts in specs
+
+- Fix metadata.json
+- Add future parser tests
+- Fix code for future parser
+- Migrate tests to rspec 3 syntax
+- Use puppet_facts in specs
 
 ## 2014-11-17 Release 1.1.4
 
-Fix acceptance tests
+- Fix acceptance tests
 
 ## 2014-11-13 Release 1.1.3
 
-Fix README
-Use Travis DPL for automatic releases
-Deprecate 2.7 support and add 3.7 support
-Lint metadata.json
+- Fix README
+- Use Travis DPL for automatic releases
+- Deprecate 2.7 support and add 3.7 support
+- Lint metadata.json
 
 ## 2014-10-20 Release 1.1.2
 
-Really setup automatic forge releases
+- Really setup automatic forge releases
 
 ## 2014-10-20 Release 1.1.0
 
-Setup automatic forge releases
+- Setup automatic forge releases
 
 ## 2014-10-07 Release 1.0.0
 
-Change usage : one must explicitely configure an openldap::server::database resource
+- Change usage : one must explicitely configure an openldap::server::database resource
 
 ## 2014-10-05 Release 0.5.3
 
-Fix service startup on RedHat
+- Fix service startup on RedHat
 
 ## 2014-09-23 Release 0.5.2
 
-Updated dependencies for augeasproviders
-Acceptance tests refactoring
+- Updated dependencies for augeasproviders
+- Acceptance tests refactoring
 
 ## 2014-09-05 Release 0.5.1
 
-Fix for ruby 1.8.7
-Fix overlay
-Use .puppet-lin.rc
-Update travis matrix
+- Fix for ruby 1.8.7
+- Fix overlay
+- Use .puppet-lin.rc
+- Update travis matrix
 
 ## 2014-08-26 Release 0.5.0
 
-User augeasproviders 2.0.0 and re-enable augeas provider.
+- User augeasproviders 2.0.0 and re-enable augeas provider.
 
 ## 2014-07-02 Release 0.4.0
 
-This release add ability to specify ldap* interfaces and thus removes openldap::server::ssl parameter. It also add a new type/provider/define to manage dbindex.
+- This release add ability to specify ldap* interfaces and thus removes openldap::server::ssl parameter. It also add a new type/provider/define to manage dbindex.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 2018-09-07 - Release 1.17.0
+
+- Drop legacy PE statement and puppet_version in metadata.json
+- Bump to minimal recommended Puppet version
+- Bump stdlib to 4.13.1 to get data types
+- Replace validate\_\* calls with datatypes
+- Drop legacy tests
+- Add Archlinux support (GH #187)
+- Ensure that the password is hashed on db creation
+- Set sensible default for dbindex attribute
+- Rewrite openldap\_password to use native Ruby
+- Fix title patterns to no longer use unsupported proc (GH #222)
+- Remove Debian 6 support and add Debian 9
+- Fix openldap\_overlap to perform add operation when adding new options
+- Support schema update via OLC
+- Add support to modify openldap\_schema resources
+
 ## 2017-06-06 - Release 1.16.1
 
 - Fix metadata.json

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group :development, :unit_tests do
   gem 'puppet-lint-unquoted_string-check',                 :require => false
   gem 'puppet-lint-empty_string-check',                    :require => false
   gem 'puppet-lint-spaceship_operator_without_tag-check',  :require => false
-  gem 'puppet-lint-absolute_classname-check',              :require => false
   gem 'puppet-lint-undef_in_function-check',               :require => false
   gem 'puppet-lint-leading_zero-check',                    :require => false
   gem 'puppet-lint-trailing_comma-check',                  :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :development, :unit_tests do
 end
 
 group :system_tests do
-  gem 'beaker',               :require => false
+  gem 'beaker', '~>3.13',     :require => false
   gem 'beaker-rspec', '> 5',  :require => false
   gem 'beaker_spec_helper',   :require => false
   gem 'serverspec',           :require => false

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ schema      | Y             | N
 Usage
 -----
 
-###Configuring the client
+### Configuring the client
 
 ```puppet
 class { 'openldap::client': }
@@ -46,7 +46,7 @@ class { 'openldap::client':
 }
 ```
 
-###Configuring the server
+### Configuring the server
 
 ```puppet
 class { 'openldap::server': }
@@ -114,7 +114,7 @@ openldap::server::globalconf { 'Security':
 	value   => { 'Security' => [ 'simple_bind=128', 'ssf=128', 'tls=0' ] } 
 ```
 
-###Configuring a database
+### Configuring a database
 
 ```puppet
 openldap::server::database { 'dc=example,dc=com':
@@ -135,7 +135,7 @@ openldap::server::database { 'dc=example,dc=com':
 }
 ```
 
-###Configuring modules
+### Configuring modules
 
 ```puppet
 openldap::server::module { 'memberof':
@@ -143,7 +143,7 @@ openldap::server::module { 'memberof':
 }
 ```
 
-###Configuring overlays
+### Configuring overlays
 
 ```puppet
 openldap::server::overlay { 'memberof on dc=example,dc=com':
@@ -151,7 +151,7 @@ openldap::server::overlay { 'memberof on dc=example,dc=com':
 }
 ```
 
-###Configuring ACPs/ACLs
+### Configuring ACPs/ACLs
 
 [Documentation](http://www.openldap.org/devel/admin/slapdconf2.html) about olcAcces state the following spec:
 > 5.2.5.2. olcAccess: to &lt;what&gt; [ by &lt;who&gt; [&lt;accesslevel&gt;] [&lt;control&gt;] ]+
@@ -207,7 +207,7 @@ openldap::server::access { '0 on frontend' :
 ```
 
 
-####Note #1:
+#### Note #1:
 The chaining arrows `->` are importants if you want to order your entries.
 Openldap put the entry as the last available position.
 So if you got in your ldap:
@@ -223,7 +223,7 @@ So if you got in your ldap:
  olcAccess: {3}to ...
 ```
 
-####Note #2:
+#### Note #2:
   The parameter `islast` is used for purging remaining entries. Only one `islast` is allowed per suffix. If you got in your ldap:
 ```
  olcAccess: {0}to ...
@@ -243,7 +243,7 @@ openldap::server::access { '1 on dc=example,dc=com':
 
 entries 2 and 3 will get deleted.
 
-####Call your acl from a hash:
+#### Call your acl from a hash:
 The class `openldap::server::access_wrapper` was designed to simplify creating ACL.
 If you have multiple `what` (`to *` in this example), you can order them by adding number to it.
 
@@ -270,7 +270,7 @@ openldap::server::access_wrapper { 'dc=example,dc=com' :
 }
 ```
 
-###Configuring Schemas
+### Configuring Schemas
 ```puppet
 openldap::server::schema { 'samba':
   ensure  => present,
@@ -285,7 +285,7 @@ openldap::server::schema { 'nis':
 }
 ```
 
-###Configuring Rewrite-overlay
+### Configuring Rewrite-overlay
 ```puppet
 openldap::server::database { 'relay':
   ensure  => present,

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ OpenLDAP
 [![Puppet Forge Downloads](http://img.shields.io/puppetforge/dt/camptocamp/openldap.svg)](https://forge.puppetlabs.com/camptocamp/openldap)
 [![Build Status](https://img.shields.io/travis/camptocamp/puppet-openldap/master.svg)](https://travis-ci.org/camptocamp/puppet-openldap)
 [![Puppet Forge Endorsement](https://img.shields.io/puppetforge/e/camptocamp/openldap.svg)](https://forge.puppetlabs.com/camptocamp/openldap)
-[![Gemnasium](https://img.shields.io/gemnasium/camptocamp/puppet-openldap.svg)](https://gemnasium.com/camptocamp/puppet-openldap)
 [![By Camptocamp](https://img.shields.io/badge/by-camptocamp-fb7047.svg)](http://www.camptocamp.com)
 
 Overview

--- a/lib/puppet/parser/functions/openldap_password.rb
+++ b/lib/puppet/parser/functions/openldap_password.rb
@@ -1,3 +1,5 @@
+require 'base64'
+
 module Puppet::Parser::Functions
   newfunction(:openldap_password, :type => :rvalue, :doc => <<-EOS
       Returns the openldap password hash from the clear text password.
@@ -7,10 +9,29 @@ module Puppet::Parser::Functions
     raise(Puppet::ParseError, "openldap_password(): Wrong number of arguments given") if args.size < 1 or args.size > 2
 
     secret = args[0]
-    command = ['slappasswd', '-s', secret]
-    scheme = args[1] if args[1]
-    command << ['-h', scheme] if scheme
+    scheme = args[1] || '{SSHA}'
 
-    Puppet::Util::Execution.execute(command.flatten).strip
+    Puppet::Parser::Functions.function('fqdn_rand_string')
+
+    case scheme[/([A-Z,0-9]+)/, 1]
+    when 'CRYPT'
+      salt = function_fqdn_rand_string([2])
+      password = '{CRYPT}' + secret.crypt(salt)
+    when 'MD5'
+      password = '{MD5}' + Digest::MD5.hexdigest(secret)
+    when 'SMD5'
+      salt = function_fqdn_rand_string([8])
+      md5_hash_with_salt = "#{Digest::MD5.digest(secret + salt)}#{salt}"
+      password = '{SMD5}' + [md5_hash_with_salt].pack('m').gsub("\n", '')
+    when 'SSHA'
+      salt = function_fqdn_rand_string([8])
+      password = '{SSHA}' + Base64.encode64("#{Digest::SHA1.digest(secret + salt)}#{salt}").chomp
+    when 'SHA'
+      password = '{SHA}' + Digest::SHA1.hexdigest(secret)
+    else
+      raise(Puppet::ParseError, "openldap_password(): Unrecognized scheme #{scheme}")
+    end
+
+    password
   end
 end

--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -60,7 +60,7 @@ Puppet::Type.
           access.position == resources[name][:position]
         else
           access.suffix == resources[name][:suffix] &&
-          access.access == resources[name][:access] &&
+          access.access.flatten == resources[name][:access].flatten &&
           access.what == resources[name][:what]
         end
       }
@@ -118,7 +118,7 @@ Puppet::Type.
     else
       t << "olcAccess: to #{resource[:what]}\n"
     end
-    resource[:access].each do |a|
+    resource[:access].flatten.each do |a|
       t << "  #{a}\n"
     end
     t.close
@@ -172,7 +172,7 @@ Puppet::Type.
   end
 
   def access=(value)
-    @property_flush[:access] = value
+    @property_flush[:access] = value.flatten
   end
 
   def islast=(value)
@@ -224,7 +224,7 @@ Puppet::Type.
       current_olcAccess.each do |olcAccess|
         if olcAccess[:position].to_i == position.to_i
           t << "olcAccess: {#{position}}to #{resource[:what]}\n"
-          resource[:access].each do |a|
+          resource[:access].flatten.each do |a|
             t << "  #{a}\n"
           end
         else

--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -57,7 +57,7 @@ Puppet::Type.
       if provider = accesses.find{ |access|
         if resources[name][:position]
           access.suffix == resources[name][:suffix] &&
-          access.position == resources[name][:position]
+          access.position == resources[name][:position].to_s
         else
           access.suffix == resources[name][:suffix] &&
           access.access.flatten == resources[name][:access].flatten &&
@@ -105,7 +105,23 @@ Puppet::Type.
   def getDn(*args); self.class.getDn(*args); end
 
   def exists?
-    @property_hash[:ensure] == :present
+    if resource[:position]
+      access = {
+        :suffix   => resource[:suffix],
+        :position => resource[:position].to_s
+      }
+    else
+      access = {
+        :suffix => resource[:suffix],
+        :access => resource[:access].flatten,
+        :what   => resource[:what]
+      }
+    end
+    accesses = self.class.instances.map { |acc|
+      acc_hash = acc.instance_variable_get(:@property_hash)
+      acc_hash.select { |k,v| access.key?(k) }
+    }
+    accesses.include?(access)
   end
 
   def create

--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -7,7 +7,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => :debian, :osfamily => :redhat
+  defaultfor :osfamily => [:debian, :redhat]
 
   mk_resource_methods
 

--- a/lib/puppet/provider/openldap_database/augeas.rb
+++ b/lib/puppet/provider/openldap_database/augeas.rb
@@ -7,6 +7,8 @@ Puppet::Type.type(:openldap_database).provide(:augeas, :parent => Puppet::Type.t
       '/etc/ldap/slapd.conf'
     when 'RedHat'
       '/etc/openldap/slapd.conf'
+    when 'Archlinux'
+      '/etc/openldap/slapd.conf'
     end
   }
 

--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -33,6 +33,7 @@ Puppet::Type.
       syncrepl = nil
       limits = []
       security = {}
+      accessrules = nil
       paragraph.gsub("\n ", "").split("\n").collect do |line|
         case line
         when /^olcDatabase: /
@@ -124,7 +125,8 @@ Puppet::Type.
         :syncusesubentry => syncusesubentry,
         :syncrepl        => syncrepl,
         :limits          => limits,
-        :security        => security
+        :security        => security,
+        :accessrules     => accessrules
       )
     end
   end
@@ -257,16 +259,18 @@ Puppet::Type.
     t << "#{resource[:limits].collect { |x| "olcLimits: #{x}" }.join("\n")}\n" if resource[:limits] and !resource[:limits].empty?
     t << "#{resource[:security].collect { |k, v| "olcSecurity: #{k}=#{v}" }.join("\n")}\n" if resource[:security] and !resource[:security].empty?
     t << "olcAccess: to * by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage by * break\n"
-    t << "olcAccess: to attrs=userPassword\n"
-    t << "  by self write\n"
-    t << "  by anonymous auth\n"
-    t << "  by dn=\"cn=admin,#{resource[:suffix]}\" write\n"
-    t << "  by * none\n"
-    t << "olcAccess: to dn.base=\"\" by * read\n"
-    t << "olcAccess: to *\n"
-    t << "  by self write\n"
-    t << "  by dn=\"cn=admin,#{resource[:suffix]}\" write\n"
-    t << "  by * read\n"
+    if resource[:accessrules] == :true
+      t << "olcAccess: to attrs=userPassword\n"
+      t << "  by self write\n"
+      t << "  by anonymous auth\n"
+      t << "  by dn=\"cn=admin,#{resource[:suffix]}\" write\n"
+      t << "  by * none\n"
+      t << "olcAccess: to dn.base=\"\" by * read\n"
+      t << "olcAccess: to *\n"
+      t << "  by self write\n"
+      t << "  by dn=\"cn=admin,#{resource[:suffix]}\" write\n"
+      t << "  by * read\n"
+    end
     t.close
     Puppet.debug(IO.read t.path)
     begin
@@ -352,6 +356,10 @@ Puppet::Type.
 
   def security=(value)
     @property_flush[:security] = value
+  end
+
+  def accessrules=(value)
+    @property_flush[:accessrules] = value
   end
 
   def flush

--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -7,7 +7,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => :debian, :osfamily => :redhat
+  defaultfor :osfamily => [:debian, :redhat]
 
   mk_resource_methods
 

--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -36,7 +36,7 @@ Puppet::Type.
       paragraph.gsub("\n ", "").split("\n").collect do |line|
         case line
         when /^olcDatabase: /
-          index, backend = line.match(/^olcDatabase: \{(\d+)\}(bdb|hdb|mdb|monitor|config|relay)$/).captures
+          index, backend = line.match(/^olcDatabase: \{(\d+)\}(bdb|hdb|mdb|monitor|config|relay)$/i).captures
         when /^olcDbDirectory: /
           directory = line.split(' ')[1]
         when /^olcRootDN: /
@@ -98,11 +98,11 @@ Puppet::Type.
           end
         end
       end
-      if backend == 'monitor' and !suffix
-        suffix = 'cn=monitor'
+      if backend.match(/monitor/i) and !suffix
+        suffix = "cn=#{backend}"
       end
-      if backend == 'config' and !suffix
-        suffix = 'cn=config'
+      if backend.match(/config/i) and !suffix
+        suffix = "cn=#{backend}"
       end
       new(
         :ensure          => :present,

--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -202,6 +202,12 @@ Puppet::Type.
   end
 
   def create
+    if resource[:rootpw] && resource[:rootpw] !~ /^\{(CRYPT|MD5|SMD5|SSHA|SHA(256|384|512)?)\}.+/
+      require 'securerandom'
+      salt = SecureRandom.random_bytes(4)
+      @resource[:rootpw] = "{SSHA}" + Base64.encode64("#{Digest::SHA1.digest("#{resource[:rootpw]}#{salt}")}#{salt}").chomp
+    end
+
     t = Tempfile.new('openldap_database')
     t << "dn: olcDatabase=#{resource[:backend]},cn=config\n"
     t << "changetype: add\n"

--- a/lib/puppet/provider/openldap_dbindex/olc.rb
+++ b/lib/puppet/provider/openldap_dbindex/olc.rb
@@ -6,7 +6,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => :debian, :osfamily => :redhat
+  defaultfor :osfamily => [:debian, :redhat]
 
   mk_resource_methods
 

--- a/lib/puppet/provider/openldap_dbtree/olc.rb
+++ b/lib/puppet/provider/openldap_dbtree/olc.rb
@@ -51,10 +51,9 @@ Puppet::Type.type(:openldap_cluster_dbtree).provide(:olc) do
 
                   # New instance
                   instances << new(
-                    :name => "#{subsuffix} #{subtree}",
+                    :tree => subtree,
                     :ensure => :present,
                     :suffix => subsuffix,
-                    :tree => subtree
                   )
                 end
               end
@@ -75,10 +74,9 @@ Puppet::Type.type(:openldap_cluster_dbtree).provide(:olc) do
 
             # New instance
             instances << new(
-              :name => "#{suffix} #{tree}",
+              :tree => tree,
               :ensure => :present,
               :suffix => suffix,
-              :tree => tree
             )
           end
         end

--- a/lib/puppet/provider/openldap_dbtree/olc.rb
+++ b/lib/puppet/provider/openldap_dbtree/olc.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:openldap_cluster_dbtree).provide(:olc) do
     suffixes  = []
 
     # Get all databases
-    databases = ldapsearch('-Q', '-LLL', '-Y', 'EXTERNAL', '-b', 'cn=config', '-H', 'ldapi:///', "(olcDbNoSync=*)").split("\n\n")
+    databases = ldapsearch('-Q', '-LLL', '-Y', 'EXTERNAL', '-b', 'cn=config', '-H', 'ldapi:///', "(olcDbDirectory=*)").split("\n\n")
 
     # Extract every database suffix
     databases.each do |block|
@@ -41,7 +41,8 @@ Puppet::Type.type(:openldap_cluster_dbtree).provide(:olc) do
 
             # New instance
             instances << new(
-              :tree => tree,
+              :name   => tree,
+              :tree   => tree,
               :ensure => :present,
               :suffix => suffix,
             )

--- a/lib/puppet/provider/openldap_dbtree/olc.rb
+++ b/lib/puppet/provider/openldap_dbtree/olc.rb
@@ -29,39 +29,6 @@ Puppet::Type.type(:openldap_cluster_dbtree).provide(:olc) do
     # Get trees for every suffix
     suffixes.each do |suffix|
 
-      # Subdomain trees
-      subdomains = ldapsearch('-Q', '-LLL', '-Y', 'EXTERNAL', '-b', suffix, '-H', 'ldapi:///', "(description=subdomain)").split("\n\n")
-      subdomains.each do |block|
-        block.gsub("\n ", "").split("\n").each do |line|
-
-          # Get the subdomain
-          if line =~ /^dc: /
-            subdomain = line.split(": ")[1]
-            subsuffix = "dc=#{subdomain},#{suffix}"
-
-            # Subtrees
-            subtrees = ldapsearch('-Q', '-LLL', '-Y', 'EXTERNAL', '-b', subsuffix, '-H', 'ldapi:///', "(objectClass=organizationalUnit)").split("\n\n")
-            subtrees.each do |tree|
-              tree.gsub("\n ", "").split("\n").each do |tree_line|
-
-                # Get the tree DN
-                if tree_line =~ /^dn: /
-                  dn = tree_line.split(": ")[1]
-                  subtree = dn.match(/^ou=([^,]*),.*$/i).captures[0]
-
-                  # New instance
-                  instances << new(
-                    :tree => subtree,
-                    :ensure => :present,
-                    :suffix => subsuffix,
-                  )
-                end
-              end
-            end
-          end
-        end
-      end
-
       # Parent database trees
       trees = ldapsearch('-Q', '-LLL', '-Y', 'EXTERNAL', '-b', suffix, '-H', 'ldapi:///', "(objectClass=organizationalUnit)").split("\n\n")
       trees.each do |block|

--- a/lib/puppet/provider/openldap_dbtree/olc.rb
+++ b/lib/puppet/provider/openldap_dbtree/olc.rb
@@ -1,0 +1,117 @@
+require 'tempfile'
+
+Puppet::Type.type(:openldap_cluster_dbtree).provide(:olc) do
+  defaultfor :operatingsystem => :debian
+
+  # Provider commands
+  commands :ldapsearch => 'ldapsearch', :ldapadd => 'ldapadd'
+
+  mk_resource_methods
+
+  def self.instances
+    instances = []
+    suffixes  = []
+
+    # Get all databases
+    databases = ldapsearch('-Q', '-LLL', '-Y', 'EXTERNAL', '-b', 'cn=config', '-H', 'ldapi:///', "(olcDbNoSync=*)").split("\n\n")
+
+    # Extract every database suffix
+    databases.each do |block|
+      db_attrs = block.gsub("\n ", "").split("\n")
+      db_attrs.each do |line|
+        if line =~ /^olcSuffix: /
+          suffix = line.split(' ')[1]
+          suffixes << suffix
+        end
+      end
+    end
+
+    # Get trees for every suffix
+    suffixes.each do |suffix|
+
+      # Subdomain trees
+      subdomains = ldapsearch('-Q', '-LLL', '-Y', 'EXTERNAL', '-b', suffix, '-H', 'ldapi:///', "(description=subdomain)").split("\n\n")
+      subdomains.each do |block|
+        block.gsub("\n ", "").split("\n").each do |line|
+
+          # Get the subdomain
+          if line =~ /^dc: /
+            subdomain = line.split(": ")[1]
+            subsuffix = "dc=#{subdomain},#{suffix}"
+
+            # Subtrees
+            subtrees = ldapsearch('-Q', '-LLL', '-Y', 'EXTERNAL', '-b', subsuffix, '-H', 'ldapi:///', "(objectClass=organizationalUnit)").split("\n\n")
+            subtrees.each do |tree|
+              tree.gsub("\n ", "").split("\n").each do |tree_line|
+
+                # Get the tree DN
+                if tree_line =~ /^dn: /
+                  dn = tree_line.split(": ")[1]
+                  subtree = dn.match(/^ou=([^,]*),.*$/i).captures[0]
+
+                  # New instance
+                  instances << new(
+                    :name => "#{subsuffix} #{subtree}",
+                    :ensure => :present,
+                    :suffix => subsuffix,
+                    :tree => subtree
+                  )
+                end
+              end
+            end
+          end
+        end
+      end
+
+      # Parent database trees
+      trees = ldapsearch('-Q', '-LLL', '-Y', 'EXTERNAL', '-b', suffix, '-H', 'ldapi:///', "(objectClass=organizationalUnit)").split("\n\n")
+      trees.each do |block|
+        block.gsub("\n ", "").split("\n").each do |line|
+
+          # Get the tree DN
+          if line =~ /^dn: /
+            dn = line.split(": ")[1]
+            tree = dn.match(/^ou=([^,]*),.*$/i).captures[0]
+
+            # New instance
+            instances << new(
+              :name => "#{suffix} #{tree}",
+              :ensure => :present,
+              :suffix => suffix,
+              :tree => tree
+            )
+          end
+        end
+      end
+    end
+    instances
+  end
+
+  def self.prefetch(resources)
+    trees = instances
+    resources.keys.each do |name|
+      if provider = trees.find{ |tree| tree.name == name }
+        resources[name].provider = provider
+      end
+    end
+  end
+
+  def create
+
+    # Tree LDIF
+    t  = Tempfile.new("ldap_dbtree")
+
+    # Generate the tree LDIF
+    t << "dn: ou=#{resource[:tree]},#{resource[:suffix]}\n"
+    t << "objectClass: organizationalUnit\n"
+    t << "ou: #{resource[:tree]}\n"
+    t.close()
+
+    # Create the database tree
+    ldapadd('-c', '-Y', 'EXTERNAL', '-H', 'ldapi:///', '-f', t.path)
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+end

--- a/lib/puppet/provider/openldap_dbtree/olc.rb
+++ b/lib/puppet/provider/openldap_dbtree/olc.rb
@@ -1,6 +1,6 @@
 require 'tempfile'
 
-Puppet::Type.type(:openldap_cluster_dbtree).provide(:olc) do
+Puppet::Type.type(:openldap_dbtree).provide(:olc) do
   defaultfor :operatingsystem => :debian
 
   # Provider commands

--- a/lib/puppet/provider/openldap_dbuser/olc.rb
+++ b/lib/puppet/provider/openldap_dbuser/olc.rb
@@ -54,7 +54,7 @@ Puppet::Type.type(:openldap_dbuser).provide(:olc) do
             # New instance
             instances << new(
               :ensure => :present,
-              :name   => "#{suffix} #{user}",
+              :name   => user,
               :suffix => suffix,
               :user   => user,
               :passwd => passwd

--- a/lib/puppet/provider/openldap_dbuser/olc.rb
+++ b/lib/puppet/provider/openldap_dbuser/olc.rb
@@ -48,6 +48,8 @@ Puppet::Type.type(:openldap_dbuser).provide(:olc) do
           # Get the user password
           if line =~ /^userPassword:: /
             passwd = line.split(":: ")[1]
+            notice("Discovered user password: #{passwd}")
+            notice("Creating new user object instance...")
 
             # New instance
             instances << new(

--- a/lib/puppet/provider/openldap_dbuser/olc.rb
+++ b/lib/puppet/provider/openldap_dbuser/olc.rb
@@ -21,7 +21,6 @@ Puppet::Type.type(:openldap_dbuser).provide(:olc) do
       db_attrs.each do |line|
         if line =~ /^olcSuffix: /
           suffix = line.split(' ')[1]
-          notice("Discovered database suffix: #{suffix}")
           suffixes << suffix
         end
       end
@@ -32,7 +31,6 @@ Puppet::Type.type(:openldap_dbuser).provide(:olc) do
 
     # Look for system user account
     suffixes.each do |suffix|
-      notice("Parsing users for suffix: #{suffix}")
 
       # Database users
       users = ldapsearch('-Q', '-LLL', '-Y', 'EXTERNAL', '-b', suffix, '-H', 'ldapi:///', "(description=user)").split("\n\n")
@@ -42,14 +40,11 @@ Puppet::Type.type(:openldap_dbuser).provide(:olc) do
           # Get the user name
           if line =~ /^cn: /
             user = line.split(": ")[1]
-            notice("Discovered user CN: #{user}")
           end
 
           # Get the user password
           if line =~ /^userPassword:: /
             passwd = line.split(":: ")[1]
-            notice("Discovered user password: #{passwd}")
-            notice("Creating new user object instance...")
 
             # New instance
             instances << new(

--- a/lib/puppet/provider/openldap_dbuser/olc.rb
+++ b/lib/puppet/provider/openldap_dbuser/olc.rb
@@ -21,6 +21,7 @@ Puppet::Type.type(:openldap_dbuser).provide(:olc) do
       db_attrs.each do |line|
         if line =~ /^olcSuffix: /
           suffix = line.split(' ')[1]
+          notice("Discovered database suffix: #{suffix}")
           suffixes << suffix
         end
       end
@@ -31,6 +32,7 @@ Puppet::Type.type(:openldap_dbuser).provide(:olc) do
 
     # Look for system user account
     suffixes.each do |suffix|
+      notice("Parsing users for suffix: #{suffix}")
 
       # Database users
       users = ldapsearch('-Q', '-LLL', '-Y', 'EXTERNAL', '-b', suffix, '-H', 'ldapi:///', "(description=user)").split("\n\n")
@@ -40,6 +42,7 @@ Puppet::Type.type(:openldap_dbuser).provide(:olc) do
           # Get the user name
           if line =~ /^cn: /
             user = line.split(": ")[1]
+            notice("Discovered user CN: #{user}")
           end
 
           # Get the user password

--- a/lib/puppet/provider/openldap_dbuser/olc.rb
+++ b/lib/puppet/provider/openldap_dbuser/olc.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:openldap_dbuser).provide(:olc) do
     suffixes  = []
 
     # Get all databases
-    databases = ldapsearch('-Q', '-LLL', '-Y', 'EXTERNAL', '-b', 'cn=config', '-H', 'ldapi:///', "(olcDbNoSync=*)").split("\n\n")
+    databases = ldapsearch('-Q', '-LLL', '-Y', 'EXTERNAL', '-b', 'cn=config', '-H', 'ldapi:///', "(olcDbDirectory=*)").split("\n\n")
 
     # Extract every database suffix
     databases.each do |block|

--- a/lib/puppet/provider/openldap_dbuser/olc.rb
+++ b/lib/puppet/provider/openldap_dbuser/olc.rb
@@ -1,0 +1,97 @@
+require 'tempfile'
+
+Puppet::Type.type(:openldap_dbuser).provide(:olc) do
+  defaultfor :osfamily => :debian, :osfamily => :redhat
+
+  # Provider commands
+  commands :ldapsearch => 'ldapsearch', :ldapmodify => 'ldapmodify'
+
+  mk_resource_methods
+
+  def self.instances
+    instances = []
+    suffixes  = []
+
+    # Get all databases
+    databases = ldapsearch('-Q', '-LLL', '-Y', 'EXTERNAL', '-b', 'cn=config', '-H', 'ldapi:///', "(olcDbNoSync=*)").split("\n\n")
+
+    # Extract every database suffix
+    databases.each do |block|
+      db_attrs = block.gsub("\n ", "").split("\n")
+      db_attrs.each do |line|
+        if line =~ /^olcSuffix: /
+          suffix = line.split(' ')[1]
+          suffixes << suffix
+        end
+      end
+    end
+
+    # Current user container
+    user = ''
+
+    # Look for system user account
+    suffixes.each do |suffix|
+
+      # Database users
+      users = ldapsearch('-Q', '-LLL', '-Y', 'EXTERNAL', '-b', suffix, '-H', 'ldapi:///', "(description=user)").split("\n\n")
+      users.each do |block|
+        block.gsub("\n ", "").split("\n").each do |line|
+
+          # Get the user name
+          if line =~ /^cn: /
+            user = line.split(": ")[1]
+          end
+
+          # Get the user password
+          if line =~ /^userPassword:: /
+            passwd = line.split(":: ")[1]
+
+            # New instance
+            instances << new(
+              :ensure => :present,
+              :name   => "#{suffix} #{user}",
+              :suffix => suffix,
+              :user   => user,
+              :passwd => passwd
+            )
+          end
+        end
+      end
+    end
+    instances
+  end
+
+  def self.prefetch(resources)
+    users = instances
+    resources.keys.each do |name|
+      if provider = users.find{ |user| user.name == name }
+        resources[name].provider = provider
+      end
+    end
+  end
+
+  def create
+    user = "cn=#{resource[:user]},#{resource[:suffix]}"
+
+    # Password LDIF / hash
+    t  = Tempfile.new("ldap_dbuser")
+
+    # Generate the attribute LDIF
+    t << "dn: #{user}\n"
+    t << "changetype: add\n"
+    t << "objectClass: top\n"
+    t << "objectClass: organizationalRole\n"
+    t << "objectClass: simpleSecurityObject\n"
+    t << "cn: #{resource[:user]}\n"
+    t << "userPassword: #{resource[:passwd]}\n"
+    t << "description: user\n"
+    t.close()
+
+    # Run the password LDIF
+    ldapmodify('-Y', 'EXTERNAL', '-H', 'ldapi:///', '-f', t.path)
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+end

--- a/lib/puppet/provider/openldap_global_conf/olc.rb
+++ b/lib/puppet/provider/openldap_global_conf/olc.rb
@@ -6,7 +6,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => :debian, :osfamily => :redhat
+  defaultfor :osfamily => [:debian, :redhat]
 
   mk_resource_methods
 

--- a/lib/puppet/provider/openldap_global_conf/olc.rb
+++ b/lib/puppet/provider/openldap_global_conf/olc.rb
@@ -45,7 +45,7 @@ Puppet::Type.
   def self.prefetch(resources)
     items = instances
     resources.keys.each do |name|
-      if provider = items.find{ |item| item.name == name }
+      if provider = items.find{ |item| item.name.downcase == name.downcase }
         resources[name].provider = provider
       end
     end

--- a/lib/puppet/provider/openldap_module/olc.rb
+++ b/lib/puppet/provider/openldap_module/olc.rb
@@ -6,7 +6,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => :debian, :osfamily => :redhat
+  defaultfor :osfamily => [:debian, :redhat]
 
   mk_resource_methods
 

--- a/lib/puppet/provider/openldap_overlay/olc.rb
+++ b/lib/puppet/provider/openldap_overlay/olc.rb
@@ -6,7 +6,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => :debian, :osfamily => :redhat
+  defaultfor :osfamily => [:debian, :redhat]
 
   mk_resource_methods
 

--- a/lib/puppet/provider/openldap_overlay/olc.rb
+++ b/lib/puppet/provider/openldap_overlay/olc.rb
@@ -205,7 +205,7 @@ Puppet::Type.
     path = default_confdir  + "/" + getPath("olcOverlay={#{@property_hash[:index]}}#{resource[:overlay]},#{getDn(resource[:suffix])}")
     File.delete(path)
 
-    slapcat("ldap:///(objectClass=olcOverlayConfig)", getDn(resource[:suffix])).
+    slapcat("(objectClass=olcOverlayConfig)", getDn(resource[:suffix])).
       split("\n").
       select { |line| line =~ /^dn: / }.
       select { |dn| dn.match(/^dn: olcOverlay=\{(\d+)\}(.+),#{Regexp.quote(getDn(resource[:suffix]))}$/).captures[0].to_i > @property_hash[:index] }.

--- a/lib/puppet/provider/openldap_overlay/olc.rb
+++ b/lib/puppet/provider/openldap_overlay/olc.rb
@@ -171,10 +171,15 @@ Puppet::Type.
         end
         # Add current options
         @property_flush[:options].each do |k, v|
-          if v.is_a?(Array)
-            t << "replace: #{k}\n#{v.collect { |x| "#{k}: #{x}" }.join("\n")}\n-\n"
+          if (@property_hash[:options] || {}).member?(k)
+            action = 'replace'
           else
-            t << "replace: #{k}\n#{k}: #{v}\n-\n"
+            action = 'add'
+          end
+          if v.is_a?(Array)
+            t << "#{action}: #{k}\n#{v.collect { |x| "#{k}: #{x}" }.join("\n")}\n-\n"
+          else
+            t << "#{action}: #{k}\n#{k}: #{v}\n-\n"
           end
         end
       end

--- a/lib/puppet/provider/openldap_overlay/olc.rb
+++ b/lib/puppet/provider/openldap_overlay/olc.rb
@@ -70,6 +70,8 @@ Puppet::Type.
     case resource[:overlay]
     when 'memberof'
       t << "objectClass: olcMemberOf\n"
+    when 'sock'
+      t << "objectClass: olcOvSocketConfig\n"
     when 'ppolicy'
       t << "objectClass: olcPPolicyConfig\n"
     when 'dynlist'

--- a/lib/puppet/provider/openldap_overlay/olc.rb
+++ b/lib/puppet/provider/openldap_overlay/olc.rb
@@ -92,6 +92,8 @@ Puppet::Type.
       t << "objectClass: olcUniqueConfig\n"
     when 'rwm'
       t << "objectClass: olcRwmConfig\n"
+    when 'sock'
+      t << "objectClass: olcOvSocketConfig\n"
     when 'smbk5pwd'
       t << "objectClass: olcSmbK5PwdConfig\n"
     end

--- a/lib/puppet/provider/openldap_ppolicy/olc.rb
+++ b/lib/puppet/provider/openldap_ppolicy/olc.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:openldap_ppolicy).provide(:olc) do
     suffixes  = []
 
     # Get all databases
-    databases = ldapsearch('-Q', '-LLL', '-Y', 'EXTERNAL', '-b', 'cn=config', '-H', 'ldapi:///', "(olcDbNoSync=*)").split("\n\n")
+    databases = ldapsearch('-Q', '-LLL', '-Y', 'EXTERNAL', '-b', 'cn=config', '-H', 'ldapi:///', "(olcDbDirectory=*)").split("\n\n")
 
     # Extract every database suffix
     databases.each do |block|

--- a/lib/puppet/provider/openldap_ppolicy/olc.rb
+++ b/lib/puppet/provider/openldap_ppolicy/olc.rb
@@ -1,0 +1,91 @@
+require 'tempfile'
+
+Puppet::Type.type(:openldap_ppolicy).provide(:olc) do
+  defaultfor :operatingsystem => :debian
+
+  # Provider commands
+  commands :ldapsearch => 'ldapsearch', :ldapadd => 'ldapadd'
+
+  mk_resource_methods
+
+  def self.instances
+    instances = []
+    suffixes  = []
+
+    # Get all databases
+    databases = ldapsearch('-Q', '-LLL', '-Y', 'EXTERNAL', '-b', 'cn=config', '-H', 'ldapi:///', "(olcDbNoSync=*)").split("\n\n")
+
+    # Extract every database suffix
+    databases.each do |block|
+      db_attrs = block.gsub("\n ", "").split("\n")
+      db_attrs.each do |line|
+        if line =~ /^olcSuffix: /
+          suffix = line.split(' ')[1]
+          suffixes << suffix
+        end
+      end
+    end
+
+    # Parse every database suffix
+    suffixes.each do |suffix|
+
+      # Password policy
+      ppolicy = ldapsearch('-Q', '-LLL', '-Y', 'EXTERNAL', '-b', suffix, '-H', 'ldapi:///', "(entryDN:=cn=default,ou=policies,#{suffix})")
+
+      # Does the policy exist
+      unless ppolicy.empty?
+        instances << new(
+          :name   => suffix,
+          :ensure => :present
+        )
+      end
+    end
+    instances
+  end
+
+  def self.prefetch(resources)
+    trees = instances
+    resources.keys.each do |name|
+      if provider = trees.find{ |tree| tree.name == name }
+        resources[name].provider = provider
+      end
+    end
+  end
+
+  def create
+
+    # Ppolicy LDIF
+    t  = Tempfile.new("ldap_ppolicy")
+
+    # Generate the ppolicy LDIF
+    t << "dn: cn=default,ou=policies,#{resource[:name]}\n"
+    t << "objectClass: top\n"
+    t << "objectClass: person\n"
+    t << "objectClass: pwdPolicy\n"
+    t << "cn: default\n"
+    t << "sn: Default Password Policy\n"
+    t << "pwdAttribute: userPassword\n"
+    t << "pwdAllowUserChange: TRUE\n"
+    t << "pwdCheckQuality: 1\n"
+    t << "pwdExpireWarning: 600\n"
+    t << "pwdFailureCountInterval: 30\n"
+    t << "pwdGraceAuthNLimit: 5\n"
+    t << "pwdInHistory: 5\n"
+    t << "pwdLockout: FALSE\n"
+    t << "pwdLockoutDuration: 0\n"
+    t << "pwdMaxAge: 0\n"
+    t << "pwdMaxFailure: 5\n"
+    t << "pwdMinAge: 0\n"
+    t << "pwdMinLength: 5\n"
+    t << "pwdMustChange: FALSE\n"
+    t << "pwdSafeModify: FALSE\n"
+    t.close()
+
+    # Create the ppolicy
+    ldapadd('-Y', 'EXTERNAL', '-H', 'ldapi:///', '-f', t.path)
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+end

--- a/lib/puppet/provider/openldap_schema/olc.rb
+++ b/lib/puppet/provider/openldap_schema/olc.rb
@@ -6,7 +6,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => :debian, :osfamily => :redhat
+  defaultfor :osfamily => [:debian, :redhat]
 
   mk_resource_methods
 

--- a/lib/puppet/type/openldap_access.rb
+++ b/lib/puppet/type/openldap_access.rb
@@ -36,51 +36,51 @@ Puppet::Type.newtype(:openldap_access) do
       [
         /^(\{(\d+)\}to\s+(\S+)\s+(by\s+.+)\s+on\s+(.+))$/,
         [
-          [ :name, lambda{|x| x} ],
-          [ :position, lambda{|x| x} ],
-          [ :what, lambda{|x| x} ],
+          [ :name ],
+          [ :position ],
+          [ :what ],
           [ :access, lambda{ |x| a=[]; x.split(/(?= by .+)/).each { |b| a << b.lstrip }; a } ],
-          [ :suffix, lambda{|x| x} ],
+          [ :suffix ],
         ],
       ],
       [
-        /^(\{(\d+)\}to\s+(\S+)\s+(by\s+.+)\s+)$/,
+        /^(\{(\d+)\}to\s+(\S+)\s+(by\s+.+))$/,
         [
-          [ :name, lambda{|x| x} ],
-          [ :position, lambda{|x| x} ],
-          [ :what, lambda{|x| x} ],
+          [ :name ],
+          [ :position ],
+          [ :what ],
           [ :access, lambda{ |x| a=[]; x.split(/(?= by .+)/).each { |b| a << b.lstrip }; a } ],
         ],
       ],
       [
         /^(to\s+(\S+)\s+(by\s+.+)\s+on\s+(.+))$/,
         [
-          [ :name, lambda{|x| x} ],
-          [ :what, lambda{|x| x} ],
+          [ :name ],
+          [ :what ],
           [ :access, lambda{ |x| a=[]; x.split(/(?= by .+)/).each { |b| a << b.lstrip }; a } ],
-          [ :suffix, lambda{|x| x} ],
+          [ :suffix ],
         ],
       ],
       [
         /^(to\s+(\S+)\s+(by\s+.+))$/,
         [
-          [ :name, lambda{|x| x} ],
-          [ :what, lambda{|x| x} ],
+          [ :name ],
+          [ :what ],
           [ :access, lambda{ |x| a=[]; x.split(/(?= by .+)/).each { |b| a << b.lstrip }; a } ],
         ],
       ],
       [
         /^((\d+)\s+on\s+(.+))$/,
         [
-          [ :name, lambda{|x| x} ],
-          [ :position, lambda{|x| x} ],
-          [ :suffix, lambda{|x| x} ],
+          [ :name ],
+          [ :position ],
+          [ :suffix ],
         ],
       ],
       [
         /(.*)/,
         [
-          [ :name, lambda{|x| x} ],
+          [ :name ],
         ],
       ],
     ]

--- a/lib/puppet/type/openldap_access.rb
+++ b/lib/puppet/type/openldap_access.rb
@@ -29,6 +29,22 @@ Puppet::Type.newtype(:openldap_access) do
 
   newproperty(:access, :array_matching => :all ) do
     desc "Access rule."
+    munge do |v|
+      if v.is_a?(String)
+        a = []
+        v.split(/(?= by .+)/).each do |b|
+          a << b.lstrip
+        end
+        a
+      else
+        v
+      end
+    end
+
+    def insync?(is)
+      @should.flatten!
+      super(is)
+    end
   end
 
   def self.title_patterns
@@ -39,7 +55,7 @@ Puppet::Type.newtype(:openldap_access) do
           [ :name ],
           [ :position ],
           [ :what ],
-          [ :access, lambda{ |x| a=[]; x.split(/(?= by .+)/).each { |b| a << b.lstrip }; a } ],
+          [ :access ],
           [ :suffix ],
         ],
       ],
@@ -49,7 +65,7 @@ Puppet::Type.newtype(:openldap_access) do
           [ :name ],
           [ :position ],
           [ :what ],
-          [ :access, lambda{ |x| a=[]; x.split(/(?= by .+)/).each { |b| a << b.lstrip }; a } ],
+          [ :access ],
         ],
       ],
       [
@@ -57,7 +73,7 @@ Puppet::Type.newtype(:openldap_access) do
         [
           [ :name ],
           [ :what ],
-          [ :access, lambda{ |x| a=[]; x.split(/(?= by .+)/).each { |b| a << b.lstrip }; a } ],
+          [ :access ],
           [ :suffix ],
         ],
       ],
@@ -66,7 +82,7 @@ Puppet::Type.newtype(:openldap_access) do
         [
           [ :name ],
           [ :what ],
-          [ :access, lambda{ |x| a=[]; x.split(/(?= by .+)/).each { |b| a << b.lstrip }; a } ],
+          [ :access ],
         ],
       ],
       [

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -227,4 +227,12 @@ Puppet::Type.newtype(:openldap_database) do
       end
     end
   end
+
+  newparam(:accessrules, :boolean => true) do
+    desc "Whether to add the default access rules to the database. It defaults to true"
+
+    newvalues(:true, :false)
+    defaultto :true
+  end
+
 end

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -207,7 +207,7 @@ Puppet::Type.newtype(:openldap_database) do
     desc "Limits the number entries returned and/or the time spent by a request"
 
     validate do |value|
-      if value !~ /^(\*|anonymous|users|self|(dn(\.\S+)?=\S+)|(dn\.\S+=\S+)|(group(\/oc(\/at)?)?=\S+))(\s+((time(\.(soft|hard))?=((\d+)|unlimited))|(size(\.(soft|hard|unchecked))?=((\d+)|unlimited))|(size\.pr=((\d+)|noEstimate|unlimited))|(size.prtotal=((\d+)|unlimited|disabled))))+$/
+      if value !~ /^(\*|anonymous|users|self|(dn(\.\S+)?=\S+)|(dn\.\S+=\S+)|(group(\/\S+(\/\S+)?)?=\S+))(\s+((time(\.(soft|hard))?=((\d+)|unlimited))|(size(\.(soft|hard|unchecked))?=((\d+)|unlimited))|(size\.pr=((\d+)|noEstimate|unlimited))|(size.prtotal=((\d+)|unlimited|disabled))))+$/
         raise ArgumentError, "Invalid limit: #{value}\nLimit values must be according to syntax described at http://www.openldap.org/doc/admin24/limits.html#Per-Database%20Limits"
       end
     end

--- a/lib/puppet/type/openldap_dbindex.rb
+++ b/lib/puppet/type/openldap_dbindex.rb
@@ -25,15 +25,15 @@ Puppet::Type.newtype(:openldap_dbindex) do
       [
         /^((\S+)\s+on\s+(.+))$/,
         [
-          [ :name, lambda{|x| x} ],
-          [ :attribute, lambda{|x| x} ],
-          [ :suffix, lambda{|x| x} ],
+          [ :name ],
+          [ :attribute ],
+          [ :suffix ],
         ],
       ],
       [
         /(.*)/,
         [
-          [ :name, lambda{|x| x} ],
+          [ :name ],
         ],
       ],
     ]

--- a/lib/puppet/type/openldap_dbtree.rb
+++ b/lib/puppet/type/openldap_dbtree.rb
@@ -3,15 +3,11 @@ Puppet::Type.newtype(:openldap_dbtree) do
 
   ensurable
 
-  newparam(:name, :namevar => true) do
-    desc "The resource name."
+  newparam(:tree, :namevar => true) do
+    desc "The tree to generate."
   end
 
   newparam(:suffix) do
     desc "The database suffix."
-  end
-
-  newparam(:tree) do
-    desc "The tree DN to ensure."
   end
 end

--- a/lib/puppet/type/openldap_dbtree.rb
+++ b/lib/puppet/type/openldap_dbtree.rb
@@ -3,11 +3,15 @@ Puppet::Type.newtype(:openldap_dbtree) do
 
   ensurable
 
-  newparam(:tree, :namevar => true) do
-    desc "The tree to generate."
+  newparam(:name, :namevar => true) do
+    desc "The default name variable."
   end
 
   newparam(:suffix) do
     desc "The database suffix."
+  end
+
+  newparam(:tree) do
+    desc "The database tree, i.e. ou=<tree>,<suffix>"
   end
 end

--- a/lib/puppet/type/openldap_dbtree.rb
+++ b/lib/puppet/type/openldap_dbtree.rb
@@ -1,0 +1,17 @@
+Puppet::Type.newtype(:openldap_dbtree) do
+  @doc = "Manages OpenLDAP database base trees."
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc "The resource name."
+  end
+
+  newparam(:suffix) do
+    desc "The database suffix."
+  end
+
+  newparam(:tree) do
+    desc "The tree DN to ensure."
+  end
+end

--- a/lib/puppet/type/openldap_dbuser.rb
+++ b/lib/puppet/type/openldap_dbuser.rb
@@ -1,0 +1,21 @@
+Puppet::Type.newtype(:openldap_dbuser) do
+  @doc = "Manages OpenLDAP system user accounts."
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc "The default name variable."
+  end
+
+  newparam(:suffix) do
+    desc "The suffix of the target database."
+  end
+
+  newparam(:user) do
+    desc "The user account CN attribute value."
+  end
+
+  newparam(:passwd) do
+    desc "The password to set for the administrator account."
+  end
+end

--- a/lib/puppet/type/openldap_overlay.rb
+++ b/lib/puppet/type/openldap_overlay.rb
@@ -28,15 +28,15 @@ Puppet::Type.newtype(:openldap_overlay) do
       [
         /^((\S+)\s+on\s+(\S+))$/,
         [
-          [ :name, lambda{|x| x} ],
-          [ :overlay, lambda{|x| x} ],
-          [ :suffix, lambda{|x| x} ],
+          [ :name ],
+          [ :overlay ],
+          [ :suffix ],
         ],
       ],
       [
         /(.*)/,
         [
-          [ :name, lambda{|x| x} ],
+          [ :name ],
         ],
       ],
     ]

--- a/lib/puppet/type/openldap_ppolicy.rb
+++ b/lib/puppet/type/openldap_ppolicy.rb
@@ -1,0 +1,9 @@
+Puppet::Type.newtype(:openldap_ppolicy) do
+  @doc = "Manages OpenLDAP password policy."
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc "The database suffix."
+  end
+end

--- a/lib/puppet/type/openldap_schema.rb
+++ b/lib/puppet/type/openldap_schema.rb
@@ -14,4 +14,12 @@ Puppet::Type.newtype(:openldap_schema) do
     end
   end
 
+  newproperty(:index) do
+    desc "The index of the schema."
+  end
+
+  newproperty(:date) do
+    desc "The modifyTimestamp of the schema."
+  end
+
 end

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -36,6 +36,13 @@ class openldap::client(
   $tls_checkpeer                                = undef,
   $tls_reqcert                                  = undef,
 
+  # SASL Options
+  $sasl_mech            = undef,
+  $sasl_realm           = undef,
+  $sasl_authcid         = undef,
+  $sasl_secprops        = undef,
+  $sasl_nocanon         = undef,
+
   # SUDO Options
   $sudoers_base                                 = undef,
 ) inherits ::openldap::params {

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -43,6 +43,11 @@ class openldap::client(
   $sasl_secprops        = undef,
   $sasl_nocanon         = undef,
 
+  # GSSAPI Options
+  $gssapi_sign                   = undef,
+  $gssapi_encrypt                = undef,
+  $gssapi_allow_remote_principal = undef,
+
   # SUDO Options
   $sudoers_base                                 = undef,
 ) inherits ::openldap::params {

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -129,6 +129,30 @@ class openldap::client::config {
     'absent' => 'rm TLS_REQCERT',
     default  => "set TLS_REQCERT ${::openldap::client::tls_reqcert}",
   }
+  $sasl_mech = $::openldap::client::sasl_mech ? {
+    undef   => undef,
+    default => "set SASL_MECH ${::openldap::client::sasl_mech}",
+  }
+  $sasl_realm = $::openldap::client::sasl_realm ? {
+    undef   => undef,
+    default => "set SASL_REALM ${::openldap::client::sasl_realm}",
+  }
+  $sasl_authcid = $::openldap::client::sasl_authcid ? {
+    undef   => undef,
+    default => "set SASL_AUTHCID ${::openldap::client::sasl_authcid}",
+  }
+  $_sasl_secprops = $::openldap::client::sasl_secprops ? {
+    undef   => undef,
+    default => join(flatten([$::openldap::client::sasl_secprops]), ','),
+  }
+  $sasl_secprops = $_sasl_secprops ? {
+    undef   => undef,
+    default => "set SASL_SECPROPS ${_sasl_secprops}",
+  }
+  $sasl_nocanon = $::openldap::client::sasl_nocanon ? {
+    undef   => undef,
+    default => "set SASL_NOCANON ${::openldap::client::sasl_nocanon}",
+  }
   $sudoers_base = $::openldap::client::sudoers_base ? {
     undef    => undef,
     'absent' => 'rm SUDOERS_BASE',
@@ -160,6 +184,11 @@ class openldap::client::config {
     $tls_cacert,
     $tls_cacertdir,
     $tls_reqcert,
+    $sasl_mech,
+    $sasl_realm,
+    $sasl_authcid,
+    $sasl_secprops,
+    $sasl_nocanon,
     $sudoers_base,
   ])
   augeas { 'ldap.conf':

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -153,6 +153,18 @@ class openldap::client::config {
     undef   => undef,
     default => "set SASL_NOCANON ${::openldap::client::sasl_nocanon}",
   }
+  $gssapi_sign = $::openldap::client::gssapi_sign ? {
+    undef   => undef,
+    default => "set GSSAPI_SIGN ${::openldap::client::gssapi_sign}",
+  }
+  $gssapi_encrypt = $::openldap::client::gssapi_encrypt ? {
+    undef   => undef,
+    default => "set GSSAPI_ENCRYPT ${::openldap::client::gssapi_encrypt}",
+  }
+  $gssapi_allow_remote_principal = $::openldap::client::gssapi_allow_remote_principal ? {
+    undef   => undef,
+    default => "set GSSAPI_ALLOW_REMOTE_PRINCIPAL ${::openldap::client::gssapi_allow_remote_principal}",
+  }
   $sudoers_base = $::openldap::client::sudoers_base ? {
     undef    => undef,
     'absent' => 'rm SUDOERS_BASE',
@@ -189,6 +201,9 @@ class openldap::client::config {
     $sasl_authcid,
     $sasl_secprops,
     $sasl_nocanon,
+    $gssapi_sign,
+    $gssapi_encrypt,
+    $gssapi_allow_remote_principal,
     $sudoers_base,
   ])
   augeas { 'ldap.conf':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,6 +32,18 @@ class openldap::params {
       $server_service_hasstatus = true
       $utils_package            = 'openldap-clients'
     }
+    'Archlinux': {
+      $client_package           = 'openldap'
+      $client_conffile          = '/etc/openldap/ldap.conf'
+      $server_confdir           = '/etc/openldap/slapd.d'
+      $server_conffile          = '/etc/openldap/slapd.conf'
+      $server_group             = 'ldap'
+      $server_owner             = 'ldap'
+      $server_package           = 'openldap'
+      $server_service           = 'slapd'
+      $server_service_hasstatus = true
+      $utils_package            = undef
+    }
     default: {
       fail "Operating System family ${::osfamily} not supported"
     }

--- a/manifests/server/access_wrapper.pp
+++ b/manifests/server/access_wrapper.pp
@@ -33,7 +33,7 @@ define openldap::server::access_wrapper (
       {
         "#{position} on #{@suffix}" => {
           "position" => position,
-          "what"     => to[/.*to (.*)/,1],
+          "what"     => to[/.*\bto (.*)/,1],
           "access"   => access,
           "suffix"   => "#{@suffix}",
         }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -69,6 +69,7 @@ class openldap::server::config {
         }
       }
     }
+    'Archlinux': {}
     default: {
       fail "Operating System Family ${::osfamily} not yet supported"
     }

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -53,12 +53,12 @@ define openldap::server::database(
   }
 
   if $ensure == present and $backend != 'monitor' and $backend != 'config' and $backend != 'relay' {
-    file { $manage_directory:
-      ensure => directory,
+    ensure_resource('file', $manage_directory, {
+      ensure => 'directory',
       owner  => $::openldap::server::owner,
       group  => $::openldap::server::group,
       before => Openldap_database[$title],
-    }
+    })
   }
 
   openldap_database { $title:

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -14,6 +14,7 @@ define openldap::server::database(
   $timelimit                                = undef,
   $updateref                                = undef,
   $limits                                   = undef,
+  $accessrules                              = true,
   # BDB/HDB options
   $dboptions                                = undef,
   $synctype                                 = undef,
@@ -83,6 +84,7 @@ define openldap::server::database(
     syncrepl        => $syncrepl,
     limits          => $limits,
     security        => $security,
+    accessrules     => $accessrules,
   }
 
 }

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -53,13 +53,11 @@ define openldap::server::database(
   }
 
   if $ensure == present and $backend != 'monitor' and $backend != 'config' and $backend != 'relay' {
-    if !defined(File[$manage_directory]) {
-      file { $manage_directory:
-        ensure => directory,
-        owner  => $::openldap::server::owner,
-        group  => $::openldap::server::group,
-        before => Openldap_database[$title],
-      }
+    file { $manage_directory:
+      ensure => directory,
+      owner  => $::openldap::server::owner,
+      group  => $::openldap::server::group,
+      before => Openldap_database[$title],
     }
   }
 

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -53,12 +53,14 @@ define openldap::server::database(
   }
 
   if $ensure == present and $backend != 'monitor' and $backend != 'config' and $backend != 'relay' {
-    ensure_resource('file', $manage_directory, {
-      ensure => 'directory',
-      owner  => $::openldap::server::owner,
-      group  => $::openldap::server::group,
-      before => Openldap_database[$title],
-    })
+    if !defined(File[$manage_directory]) {
+      file { $manage_directory:
+        ensure => directory,
+        owner  => $::openldap::server::owner,
+        group  => $::openldap::server::group,
+        before => Openldap_database[$title],
+      }
+    }
   }
 
   openldap_database { $title:

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -53,11 +53,13 @@ define openldap::server::database(
   }
 
   if $ensure == present and $backend != 'monitor' and $backend != 'config' and $backend != 'relay' {
-    file { $manage_directory:
-      ensure => directory,
-      owner  => $::openldap::server::owner,
-      group  => $::openldap::server::group,
-      before => Openldap_database[$title],
+    if ! defined(File[$manage_directory]) {
+      file { $manage_directory:
+        ensure => directory,
+        owner  => $::openldap::server::owner,
+        group  => $::openldap::server::group,
+        before => Openldap_database[$title],
+      }
     }
   }
 

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -47,7 +47,7 @@ define openldap::server::database(
     -> Openldap::Server::Database[$title]
     -> Class['openldap::server']
   }
-  if $title != 'dc=my-domain,dc=com' {
+  if $title != 'dc=my-domain,dc=com' and $::osfamily == 'Debian' {
     Openldap::Server::Database['dc=my-domain,dc=com'] -> Openldap::Server::Database[$title]
   }
 

--- a/manifests/server/dbindex.pp
+++ b/manifests/server/dbindex.pp
@@ -2,7 +2,7 @@
 define openldap::server::dbindex(
   $ensure    = undef,
   $suffix    = undef,
-  $attribute = $title,
+  $attribute = $name,
   $indices   = undef,
 ) {
 

--- a/manifests/server/dbindex.pp
+++ b/manifests/server/dbindex.pp
@@ -2,7 +2,7 @@
 define openldap::server::dbindex(
   $ensure    = undef,
   $suffix    = undef,
-  $attribute = undef,
+  $attribute = $title,
   $indices   = undef,
 ) {
 

--- a/manifests/server/dbtree.pp
+++ b/manifests/server/dbtree.pp
@@ -24,5 +24,6 @@ define openldap::server::dbtree(
   openldap_dbtree { $title:
     ensure => $ensure,
     suffix => $suffix,
+    tree   => $tree,
   }
 }

--- a/manifests/server/dbtree.pp
+++ b/manifests/server/dbtree.pp
@@ -1,0 +1,28 @@
+# See README.md for details.
+define openldap::server::dbtree(
+  $ensure = 'present',
+  $suffix = undef,
+  $tree   = $title,
+) {
+
+  if ! defined(Class['openldap::server']) {
+    fail 'class ::openldap::server has not been evaluated'
+  }
+
+  if $::openldap::server::provider == 'augeas' {
+    Class['openldap::server::install']
+    -> Openldap::Server::Database[$suffix]
+    -> Openldap::Server::Dbtree[$title]
+    ~> Class['openldap::server::service']
+  } else {
+    Class['openldap::server::service']
+    -> Openldap::Server::Database[$suffix]
+    -> Openldap::Server::Dbtree[$title]
+    -> Class['openldap::server']
+  }
+
+  openldap_dbtree { $title:
+    ensure => $ensure,
+    suffix => $suffix,
+  }
+}

--- a/manifests/server/dbuser.pp
+++ b/manifests/server/dbuser.pp
@@ -1,0 +1,31 @@
+# See README.md for details.
+define openldap::server::dbuser(
+  $ensure = 'present',
+  $suffix = undef,
+  $user   = $title,
+  $passwd = undef,
+) {
+
+  if ! defined(Class['openldap::server']) {
+    fail 'class ::openldap::server has not been evaluated'
+  }
+
+  if $::openldap::server::provider == 'augeas' {
+    Class['openldap::server::install']
+    -> Openldap::Server::Database[$suffix]
+    -> Openldap::Server::Dbuser[$title]
+    ~> Class['openldap::server::service']
+  } else {
+    Class['openldap::server::service']
+    -> Openldap::Server::Database[$suffix]
+    -> Openldap::Server::Dbuser[$title]
+    -> Class['openldap::server']
+  }
+
+  openldap_dbuser { $title:
+    ensure   => $ensure,
+    suffix   => $suffix,
+    user     => $user,
+    passwd   => $passwd,
+  }
+}

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -18,11 +18,9 @@ class openldap::server::install {
       content => "slapd slapd/domain\tstring\tmy-domain.com\n",
       before  => Package[$::openldap::server::package],
     }
-  }
-
-  $responsefile = $::osfamily ? {
-    'Debian' => '/var/cache/debconf/slapd.preseed',
-    'RedHat' => undef,
+    $responsefile = '/var/cache/debconf/slapd.preseed'
+  } else {
+    $responsefile = undef
   }
 
   package { $::openldap::server::package:

--- a/manifests/server/overlay.pp
+++ b/manifests/server/overlay.pp
@@ -12,10 +12,12 @@ define openldap::server::overlay(
 
   if $::openldap::server::provider == 'augeas' {
     Class['openldap::server::install']
+    -> Openldap::Server::Database[$suffix]
     -> Openldap::Server::Overlay[$title]
     ~> Class['openldap::server::service']
   } else {
     Class['openldap::server::service']
+    -> Openldap::Server::Database[$suffix]
     -> Openldap::Server::Overlay[$title]
     -> Class['openldap::server']
   }

--- a/manifests/server/ppolicy.pp
+++ b/manifests/server/ppolicy.pp
@@ -1,0 +1,24 @@
+# See README.md for details.
+define openldap::server::ppolicy(
+  $ensure = undef,
+) {
+
+  if ! defined(Class['openldap::server']) {
+    fail 'class ::openldap::server has not been evaluated'
+  }
+
+  if $::openldap::server::provider == 'augeas' {
+    Class['openldap::server::install']
+    -> Openldap::Server::Ppolicy[$title]
+    ~> Class['openldap::server::service']
+  } else {
+    Class['openldap::server::service']
+    -> Openldap::Server::Ppolicy[$title]
+    -> Class['openldap::server']
+  }
+
+  openldap_ppolicy { $title:
+    ensure   => $ensure,
+    provider => $::openldap::server::provider,
+  }
+}

--- a/manifests/server/schema.pp
+++ b/manifests/server/schema.pp
@@ -4,6 +4,7 @@ define openldap::server::schema(
   $path          = $::osfamily ? {
     'Debian' => "/etc/ldap/schema/${title}.schema",
     'Redhat' => "/etc/openldap/schema/${title}.schema",
+    'Archlinux' => "/etc/openldap/schema/${title}.schema",
   }
 ) {
 
@@ -16,15 +17,18 @@ define openldap::server::schema(
     Class['openldap::server::install']
     -> Openldap::Server::Schema[$title]
     ~> Class['openldap::server::service']
+    file_line{$title:
+      path => $::openldap::server::conffile,
+      line => "include ${path}",
+    }
   } else {
     Class['openldap::server::service']
     -> Openldap::Server::Schema[$title]
     -> Class['openldap::server']
-  }
-
-  openldap_schema { $title:
-    ensure   => $ensure,
-    path     => $path,
-    provider => $::openldap::server::provider,
+    openldap_schema { $title:
+      ensure   => $ensure,
+      path     => $path,
+      provider => $::openldap::server::provider,
+    }
   }
 }

--- a/manifests/server/slapdconf.pp
+++ b/manifests/server/slapdconf.pp
@@ -48,8 +48,10 @@ class openldap::server::slapdconf {
     fail 'You must specify a ssl_cert'
   }
 
-  openldap::server::database { 'dc=my-domain,dc=com':
-    ensure => absent,
+  if $::osfamily == 'Debian' {
+    openldap::server::database { 'dc=my-domain,dc=com':
+      ensure => absent,
+    }
   }
 
   create_resources('openldap::server::database', $::openldap::server::databases)

--- a/manifests/utils.pp
+++ b/manifests/utils.pp
@@ -2,7 +2,9 @@
 class openldap::utils(
   $package = $openldap::params::utils_package,
 ) inherits ::openldap::params {
-  package { $package:
-    ensure => present,
+  if $package {
+    package { $package:
+      ensure => present,
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -31,9 +31,9 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.13.1 <5.0.0"
+      "version_requirement": ">=4.13.1 < 6.0.0"
     },
     {
       "name": "herculesteam/augeasproviders_core",

--- a/metadata.json
+++ b/metadata.json
@@ -31,7 +31,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
       ]

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "camptocamp-openldap",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "author": "Camptocamp",
   "summary": "Puppet OpenLDAP module",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -24,7 +24,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.6.1 < 5.0.0"
+      "version_requirement": ">= 4.6.1 < 6.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/openldap__server__access_spec.rb
+++ b/spec/acceptance/openldap__server__access_spec.rb
@@ -35,6 +35,16 @@ describe 'openldap::server::access' do
           suffix  => 'dc=example,dc=com',
           require => Openldap::Server::Database['dc=example,dc=com'],
         }
+        ::openldap::server::access { 'root':
+          what    => '*',
+          access  => [
+            'by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage',
+            'by * break'
+          ],
+          suffix  => 'dc=example,dc=com',
+          position => 0,
+          require => Openldap::Server::Database['dc=example,dc=com'],
+        }
       EOS
 
       apply_manifest(pp, :catch_failures => true)

--- a/spec/acceptance/overlay_spec.rb
+++ b/spec/acceptance/overlay_spec.rb
@@ -20,7 +20,32 @@ describe 'openldap::server::overlay' do
       EOS
 
       apply_manifest(pp, :catch_failures => true)
-      #apply_manifest(pp, :catch_changes => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+  end
+
+  context 'options defined' do
+    it 'adds option to overlay' do
+      pp = <<-EOS
+      class { 'openldap::server': }
+      openldap::server::database { 'dc=foo,dc=bar':
+        ensure => present,
+      }
+      ->
+      openldap::server::module { 'memberof':
+        ensure => present,
+      }
+      ->
+      openldap::server::overlay { 'memberof on dc=foo,dc=bar':
+        ensure  => present,
+        options => {
+          'olcMemberOfGroupOC' => 'groupOfNames',
+        }
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
     end
   end
 end

--- a/spec/acceptance/schema_spec.rb
+++ b/spec/acceptance/schema_spec.rb
@@ -15,6 +15,102 @@ describe 'openldap::server::schema' do
       apply_manifest(pp, :catch_changes => true)
     end
   end
+
+  context 'adds custom schema' do
+    it 'adds puppet schema' do
+      fixture = File.expand_path(File.join(File.dirname(__FILE__), '../fixtures/schema/puppet1.schema'))
+      scp_to(hosts, fixture, '/tmp/puppet1.schema')
+      pp = <<-EOS
+      class { 'openldap::server': }
+      file { '/tmp/puppet.schema':
+        ensure => 'present',
+        source => '/tmp/puppet1.schema',
+      }
+      -> openldap::server::schema { 'puppet':
+        ensure => present,
+        path   => '/tmp/puppet.schema',
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+  end
+
+  context 'modifies custom schema' do
+    it 'modifies puppet schema' do
+      fixture = File.expand_path(File.join(File.dirname(__FILE__), '../fixtures/schema/puppet2.schema'))
+      scp_to(hosts, fixture, '/tmp/puppet2.schema')
+      pp = <<-EOS
+      class { 'openldap::server': }
+      file { '/tmp/puppet.schema':
+        ensure => 'present',
+        source => '/tmp/puppet2.schema',
+      }
+      -> openldap::server::schema { 'puppet':
+        ensure => present,
+        path   => '/tmp/puppet.schema',
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+  end
+
+  context 'remove custom schema' do
+    it 'cleans up custom schema' do
+      on hosts, 'service slapd stop'
+      if fact(:osfamily) == 'Debian'
+        on hosts, 'rm -f /etc/ldap/slapd.d/cn=config/cn=schema/*puppet.ldif'
+      else
+        on hosts, 'rm -f /etc/openldap/slapd.d/cn=config/cn=schema/*puppet.ldif'
+      end
+      on hosts, 'service slapd start'
+    end
+  end
+
+  context 'adds custom ldif schema' do
+    it 'adds puppet schema' do
+      fixture = File.expand_path(File.join(File.dirname(__FILE__), '../fixtures/schema/puppet1.ldif'))
+      scp_to(hosts, fixture, '/tmp/puppet1.ldif')
+      pp = <<-EOS
+      class { 'openldap::server': }
+      file { '/tmp/puppet.ldif':
+        ensure => 'present',
+        source => '/tmp/puppet1.ldif',
+      }
+      -> openldap::server::schema { 'puppet':
+        ensure => present,
+        path   => '/tmp/puppet.ldif',
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+  end
+
+  context 'modifies custom ldif schema' do
+    it 'modifies puppet schema' do
+      fixture = File.expand_path(File.join(File.dirname(__FILE__), '../fixtures/schema/puppet2.ldif'))
+      scp_to(hosts, fixture, '/tmp/puppet2.ldif')
+      pp = <<-EOS
+      class { 'openldap::server': }
+      file { '/tmp/puppet.ldif':
+        ensure => 'present',
+        source => '/tmp/puppet2.ldif',
+      }
+      -> openldap::server::schema { 'puppet':
+        ensure => present,
+        path   => '/tmp/puppet.ldif',
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+  end
 end
 
 

--- a/spec/classes/openldap_client_config_spec.rb
+++ b/spec/classes/openldap_client_config_spec.rb
@@ -665,6 +665,44 @@ describe 'openldap::client::config' do
         end
       end
 
+      context 'with sasl options set' do
+        let :pre_condition do
+          "class {'openldap::client':
+                   sasl_mech => 'gssapi',
+                   sasl_realm => 'TEST.REALM',
+                   sasl_authcid => 'dn:uid=test,cn=mech,cn=authzid',
+                   sasl_secprops => ['noplain','noactive'],
+                   sasl_nocanon => true,
+           }"
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('openldap::client::config') }
+        it { is_expected.to contain_augeas('ldap.conf') }
+        case facts[:osfamily]
+        when 'Debian'
+          it { is_expected.to contain_augeas('ldap.conf').with({
+            :incl    => '/etc/ldap/ldap.conf',
+            :changes => [ 'set SASL_MECH gssapi',
+                          'set SASL_REALM TEST.REALM',
+                          'set SASL_AUTHCID dn:uid=test,cn=mech,cn=authzid',
+                          'set SASL_SECPROPS noplain,noactive',
+                          'set SASL_NOCANON true'],
+          })
+          }
+        when 'RedHat'
+          it { is_expected.to contain_augeas('ldap.conf').with({
+            :incl    => '/etc/openldap/ldap.conf',
+            :changes => [ 'set SASL_MECH gssapi',
+                          'set SASL_REALM TEST.REALM',
+                          'set SASL_AUTHCID dn:uid=test,cn=mech,cn=authzid',
+                          'set SASL_SECPROPS noplain,noactive',
+                          'set SASL_NOCANON true'],
+          })
+          }
+        end
+      end
+
       context 'with sudoers_base set' do
         let :pre_condition do
           "class {'openldap::client': sudoers_base => 'ou=sudoers,dc=example,dc=com', }"

--- a/spec/classes/openldap_client_config_spec.rb
+++ b/spec/classes/openldap_client_config_spec.rb
@@ -703,6 +703,38 @@ describe 'openldap::client::config' do
         end
       end
 
+      context 'with gssapi options set' do
+        let :pre_condition do
+          "class {'openldap::client':
+                   gssapi_sign => false,
+                   gssapi_encrypt => true,
+                   gssapi_allow_remote_principal => 'on'
+           }"
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('openldap::client::config') }
+        it { is_expected.to contain_augeas('ldap.conf') }
+        case facts[:osfamily]
+        when 'Debian'
+          it { is_expected.to contain_augeas('ldap.conf').with({
+            :incl    => '/etc/ldap/ldap.conf',
+            :changes => [ 'set GSSAPI_SIGN false',
+                          'set GSSAPI_ENCRYPT true',
+                          'set GSSAPI_ALLOW_REMOTE_PRINCIPAL on'],
+          })
+          }
+        when 'RedHat'
+          it { is_expected.to contain_augeas('ldap.conf').with({
+            :incl    => '/etc/openldap/ldap.conf',
+            :changes => [ 'set GSSAPI_SIGN false',
+                          'set GSSAPI_ENCRYPT true',
+                          'set GSSAPI_ALLOW_REMOTE_PRINCIPAL on'],
+          })
+          }
+        end
+      end
+
       context 'with sudoers_base set' do
         let :pre_condition do
           "class {'openldap::client': sudoers_base => 'ou=sudoers,dc=example,dc=com', }"

--- a/spec/classes/openldap_server_slapdconf_spec.rb
+++ b/spec/classes/openldap_server_slapdconf_spec.rb
@@ -14,7 +14,12 @@ describe 'openldap::server::slapdconf' do
         end
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('openldap::server::slapdconf') }
-        it { is_expected.to contain_openldap__server__database('dc=my-domain,dc=com').with({:ensure => :absent,})}
+        case facts[:osfamily]
+        when 'Debian'
+          it { is_expected.to contain_openldap__server__database('dc=my-domain,dc=com').with({:ensure => :absent,})}
+        else
+          it { is_expected.not_to contain_openldap__server__database('dc=my-domain,dc=com').with({:ensure => :absent,})}
+        end
       end
     end
   end

--- a/spec/classes/openldap_server_spec.rb
+++ b/spec/classes/openldap_server_spec.rb
@@ -28,8 +28,6 @@ describe 'openldap::server' do
                that_comes_before('Class[openldap::server::slapdconf]') }
           it { is_expected.to contain_class('openldap::server::slapdconf').
                that_comes_before('Class[openldap::server]') }
-          it { is_expected.to have_openldap__server__database_resource_count(1) }
-          it { is_expected.to contain_openldap__server__database('dc=my-domain,dc=com').with({:ensure => :absent,})}
           case facts[:osfamily]
           when 'Debian'
             it { is_expected.to contain_class('openldap::server').with({
@@ -42,6 +40,8 @@ describe 'openldap::server' do
               :ssl_key  => nil,
               :ssl_ca   => nil,
             })}
+            it { is_expected.to contain_openldap__server__database('dc=my-domain,dc=com').with({:ensure => :absent,})}
+            it { is_expected.to have_openldap__server__database_resource_count(1) }
           when 'RedHat'
             case facts[:operatingsystemmajrelease]
             when '5'
@@ -55,6 +55,7 @@ describe 'openldap::server' do
                 :ssl_key  => nil,
                 :ssl_ca   => nil,
               })}
+            it { is_expected.to have_openldap__server__database_resource_count(0) }
             else
               it { is_expected.to contain_class('openldap::server').with({
                 :package  => 'openldap-servers',
@@ -66,6 +67,7 @@ describe 'openldap::server' do
                 :ssl_key  => nil,
                 :ssl_ca   => nil,
               })}
+            it { is_expected.to have_openldap__server__database_resource_count(0) }
             end
           end
         end

--- a/spec/fixtures/schema/puppet1.ldif
+++ b/spec/fixtures/schema/puppet1.ldif
@@ -1,0 +1,15 @@
+dn: cn=puppet,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: puppet
+olcAttributeTypes: (  1.3.6.1.4.1.34380.1.1.3.10 NAME 'puppetClass'
+  DESC 'Puppet Node Class'
+  EQUALITY caseIgnoreIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.34380.1.1.3.9 NAME 'parentNode'
+  DESC 'Puppet Parent Node'
+  EQUALITY caseIgnoreIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE )
+olcObjectClasses: ( 1.3.6.1.4.1.34380.1.1.1.2 NAME 'puppetClient' SUP top AUXILIARY
+  DESC 'Puppet Client objectclass'
+  MAY ( puppetclass $ parentnode ))

--- a/spec/fixtures/schema/puppet1.schema
+++ b/spec/fixtures/schema/puppet1.schema
@@ -1,0 +1,14 @@
+attributetype (  1.3.6.1.4.1.34380.1.1.3.10 NAME 'puppetClass'
+	DESC 'Puppet Node Class'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.4.1.34380.1.1.3.9 NAME 'parentNode'
+	DESC 'Puppet Parent Node'
+	EQUALITY caseIgnoreIA5Match
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+        SINGLE-VALUE )
+
+objectclass ( 1.3.6.1.4.1.34380.1.1.1.2 NAME 'puppetClient' SUP top AUXILIARY
+	DESC 'Puppet Client objectclass'
+	MAY ( puppetclass $ parentnode ))

--- a/spec/fixtures/schema/puppet2.ldif
+++ b/spec/fixtures/schema/puppet2.ldif
@@ -1,0 +1,23 @@
+dn: cn=puppet,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: puppet
+olcAttributeTypes: (  1.3.6.1.4.1.34380.1.1.3.10 NAME 'puppetClass'
+  DESC 'Puppet Node Class'
+  EQUALITY caseIgnoreIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.34380.1.1.3.9 NAME 'parentNode'
+  DESC 'Puppet Parent Node'
+  EQUALITY caseIgnoreIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.4.1.34380.1.1.3.11 NAME 'environment'
+  DESC 'Puppet Node Environment'
+  EQUALITY caseIgnoreIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.34380.1.1.3.12 NAME 'puppetVar'
+ DESC 'A variable setting for puppet'
+ EQUALITY caseIgnoreIA5Match
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcObjectClasses: ( 1.3.6.1.4.1.34380.1.1.1.2 NAME 'puppetClient' SUP top AUXILIARY
+  DESC 'Puppet Client objectclass'
+  MAY ( puppetclass $ parentnode $ environment $ puppetVar ))

--- a/spec/fixtures/schema/puppet2.schema
+++ b/spec/fixtures/schema/puppet2.schema
@@ -1,0 +1,24 @@
+attributetype (  1.3.6.1.4.1.34380.1.1.3.10 NAME 'puppetClass'
+	DESC 'Puppet Node Class'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.4.1.34380.1.1.3.9 NAME 'parentNode'
+	DESC 'Puppet Parent Node'
+	EQUALITY caseIgnoreIA5Match
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+        SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.4.1.34380.1.1.3.11 NAME 'environment'
+	DESC 'Puppet Node Environment'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.4.1.34380.1.1.3.12 NAME 'puppetVar'
+	DESC 'A variable setting for puppet'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+objectclass ( 1.3.6.1.4.1.34380.1.1.1.2 NAME 'puppetClient' SUP top AUXILIARY
+	DESC 'Puppet Client objectclass'
+	MAY ( puppetclass $ parentnode $ environment $ puppetvar ))

--- a/spec/unit/puppet/parser/functions/openldap_password_spec.rb
+++ b/spec/unit/puppet/parser/functions/openldap_password_spec.rb
@@ -16,20 +16,30 @@ describe Puppet::Parser::Functions.function(:openldap_password) do
   end
 
   context 'when given only a secret' do
-    it 'should execute slappasswd on it' do
-      Puppet::Util::Execution.stubs(:execute).with([
-        'slappasswd', '-s', 'foo'
-      ]).returns("{SSHA}kKSBVuPOwlHp5HfcR3LBKyB7smTnbq9Y\n")
-      expect(scope.function_openldap_password(['foo'])).to eq('{SSHA}kKSBVuPOwlHp5HfcR3LBKyB7smTnbq9Y')
+    it 'should generate password' do
+      scope.stubs(:function_fqdn_rand_string).with([8]).returns('abcdefgh')
+      expect(scope.function_openldap_password(['foo'])).to eq("{SSHA}3RXLE64s+3ytIRdJYu9eoU8O/alhYmNkZWZnaA==")
     end
   end
 
   context 'when given a secret and a scheme' do
-    it 'should execute slappasswd on them' do
-      Puppet::Util::Execution.stubs(:execute).with([
-        'slappasswd', '-s', 'foo', '-h', '{MD5}'
-      ]).returns("{MD5}rL0Y20zC+Fzt72VPzMSk2A==\n")
-      expect(scope.function_openldap_password(['foo', '{MD5}'])).to eq('{MD5}rL0Y20zC+Fzt72VPzMSk2A==')
+    it 'should generate CRYPT password' do
+      scope.stubs(:function_fqdn_rand_string).with([2]).returns('ab')
+      expect(scope.function_openldap_password(['foo', 'CRYPT'])).to eq("{CRYPT}abQ9KY.KfrYrc")
+    end
+    it 'should generate MD5 password' do
+      expect(scope.function_openldap_password(['foo', 'MD5'])).to eq("{MD5}acbd18db4cc2f85cedef654fccc4a4d8")
+    end
+    it 'should generate SMD5 password' do
+      scope.stubs(:function_fqdn_rand_string).with([8]).returns('abcdefgh')
+      expect(scope.function_openldap_password(['foo', 'SMD5'])).to eq("{SMD5}NAYSvQYSIRYBLCM8U6MUc2FiY2RlZmdo")
+    end
+    it 'should generate SSHA password' do
+      scope.stubs(:function_fqdn_rand_string).with([8]).returns('abcdefgh')
+      expect(scope.function_openldap_password(['foo', 'SSHA'])).to eq("{SSHA}3RXLE64s+3ytIRdJYu9eoU8O/alhYmNkZWZnaA==")
+    end
+    it 'should generate SHA password' do
+      expect(scope.function_openldap_password(['foo', 'SHA'])).to eq("{SHA}0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33")
     end
   end
 end

--- a/spec/unit/puppet/type/openldap_acess_spec.rb
+++ b/spec/unit/puppet/type/openldap_acess_spec.rb
@@ -6,7 +6,7 @@ describe Puppet::Type.type(:openldap_access) do
       access = described_class.new(:name => 'to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
       expect(access[:name]).to eq('to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
       expect(access[:what]).to eq('attrs=userPassword,shadowLastChange')
-      expect(access[:access]).to eq(['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth'])
+      expect(access[:access]).to eq([['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth']])
     end
 
     it 'should handle componsite name with position' do
@@ -14,7 +14,7 @@ describe Puppet::Type.type(:openldap_access) do
       expect(access[:name]).to eq('{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
       expect(access[:position]).to eq('0')
       expect(access[:what]).to eq('attrs=userPassword,shadowLastChange')
-      expect(access[:access]).to eq(['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth'])
+      expect(access[:access]).to eq([['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth']])
     end
 
     it 'should handle componsite name with position' do
@@ -22,8 +22,20 @@ describe Puppet::Type.type(:openldap_access) do
       expect(access[:name]).to eq('{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth on dc=example,dc=com')
       expect(access[:position]).to eq('0')
       expect(access[:what]).to eq('attrs=userPassword,shadowLastChange')
-      expect(access[:access]).to eq(['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth'])
+      expect(access[:access]).to eq([['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth']])
       expect(access[:suffix]).to eq('dc=example,dc=com')
+    end
+  end
+
+  describe 'access' do
+    it 'should handle array of values' do
+      access = described_class.new(:name => 'foo', :access => ['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth'])
+      expect(access[:access]).to eq([['by dn="cn=admin,dc=example,dc=com" write'], ['by anonymous auth']])
+    end
+
+    it 'should handle string' do
+      access = described_class.new(:name => 'foo', :access => 'by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
+      expect(access[:access]).to eq([['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth']])
     end
   end
 end

--- a/spec/unit/puppet/type/openldap_acess_spec.rb
+++ b/spec/unit/puppet/type/openldap_acess_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:openldap_access) do
+  describe 'namevar title patterns' do
+    it 'should handle componsite name' do
+      access = described_class.new(:name => 'to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
+      expect(access[:name]).to eq('to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
+      expect(access[:what]).to eq('attrs=userPassword,shadowLastChange')
+      expect(access[:access]).to eq(['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth'])
+    end
+
+    it 'should handle componsite name with position' do
+      access = described_class.new(:name => '{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
+      expect(access[:name]).to eq('{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
+      expect(access[:position]).to eq('0')
+      expect(access[:what]).to eq('attrs=userPassword,shadowLastChange')
+      expect(access[:access]).to eq(['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth'])
+    end
+
+    it 'should handle componsite name with position' do
+      access = described_class.new(:name => '{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth on dc=example,dc=com')
+      expect(access[:name]).to eq('{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth on dc=example,dc=com')
+      expect(access[:position]).to eq('0')
+      expect(access[:what]).to eq('attrs=userPassword,shadowLastChange')
+      expect(access[:access]).to eq(['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth'])
+      expect(access[:suffix]).to eq('dc=example,dc=com')
+    end
+  end
+end


### PR DESCRIPTION
This updates the module in order to fix the messages below:
```
Error: /etc/puppetlabs/code/environments/papercuts/modules/openldap/lib/puppet/type/openldap_access.rb: title patterns that use procs are not supported.
Error: /etc/puppetlabs/code/environments/papercuts/modules/openldap/lib/puppet/type/openldap_dbindex.rb: title patterns that use procs are not supported.
Error: /etc/puppetlabs/code/environments/papercuts/modules/openldap/lib/puppet/type/openldap_overlay.rb: title patterns that use procs are not supported.
Error: /etc/puppetlabs/code/environments/papercuts/modules/openldap_cluster/lib/puppet/type/openldap_cluster_overlay.rb: title patterns that use procs are not supported.
```